### PR TITLE
chore(seo): add robots.txt and dynamic sitemap metadata route

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next'
+
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+	const routes = ['', '/education', '/medical-records', '/traditional-medicine', '/telemedicine', '/create']
+	const lastModified = new Date()
+
+	return routes.map((path) => ({
+		url: `${baseUrl}${path || '/'}`,
+		lastModified,
+		changeFrequency: 'weekly',
+		priority: path === '' ? 1 : 0.7,
+	}))
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: /sitemap.xml


### PR DESCRIPTION
### Summary
Adds basic SEO scaffolding: static `robots.txt` and a dynamic `sitemap.xml`.

### What’s Changed
- Added `public/robots.txt` to allow all bots and reference sitemap.
- Implemented dynamic sitemap via Next.js metadata route in `app/sitemap.ts`.
  - Includes core routes: `/`, `/education`, `/medical-records`, `/traditional-medicine`, `/telemedicine`, `/create`.
  - Uses `NEXT_PUBLIC_SITE_URL` for absolute URLs (defaults to `http://localhost:3000` if unset).

### Why
Search engines were missing essential discovery files.

### How to Test
- Start the app and verify:
  - `GET /robots.txt` returns allow-all rules and a `Sitemap: /sitemap.xml` reference.
  - `GET /sitemap.xml` returns XML with the expected URLs and absolute links based on `NEXT_PUBLIC_SITE_URL`.
- Optionally set `NEXT_PUBLIC_SITE_URL` locally (e.g., `http://localhost:3000`) and re-check absolute URLs.

### Notes
- Ensure `NEXT_PUBLIC_SITE_URL` is set in the deployment environment to your production domain.

### Checklist
- [x] Adds `public/robots.txt`
- [x] Adds dynamic Next.js sitemap route
- [x] No linter errors
- [x] Non-breaking change

Closes #13