### PR TITLE
feat: add offline-first medical records UI

### DIFF
--- a/frontend-v2/app/medical-records/components/MedicalRecordForm.tsx
+++ b/frontend-v2/app/medical-records/components/MedicalRecordForm.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { addRecord, simulateSync } from "../lib/indexedDb";
+
+interface MedicalRecordFormProps {
+  onRecordAdded: () => void;
+}
+
+export default function MedicalRecordForm({ onRecordAdded }: MedicalRecordFormProps) {
+  const [patientName, setPatientName] = useState("");
+  const [age, setAge] = useState("");
+  const [diagnosis, setDiagnosis] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!patientName || !age || !diagnosis) {
+      alert("Please fill in all fields");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const newRecord = {
+        patientName,
+        age: parseInt(age, 10),
+        diagnosis,
+        syncStatus: "pending" as const,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      // Save to IndexedDB
+      const recordId = await addRecord(newRecord);
+
+      // Reset form
+      setPatientName("");
+      setAge("");
+      setDiagnosis("");
+
+      // Notify parent to refresh list
+      onRecordAdded();
+
+      // Simulate sync after 2-3 seconds
+      simulateSync(recordId, 2500).then(() => {
+        onRecordAdded(); // Refresh to show updated status
+      });
+    } catch (error) {
+      console.error("Error saving record:", error);
+      alert("Failed to save medical record");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Create Medical Record</CardTitle>
+        <CardDescription>Add a new patient medical record</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="patientName">Patient Name</Label>
+            <Input
+              id="patientName"
+              type="text"
+              placeholder="Enter patient name"
+              value={patientName}
+              onChange={(e) => setPatientName(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="age">Age</Label>
+            <Input
+              id="age"
+              type="number"
+              placeholder="Enter age"
+              value={age}
+              onChange={(e) => setAge(e.target.value)}
+              min="0"
+              max="150"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="diagnosis">Diagnosis</Label>
+            <Textarea
+              id="diagnosis"
+              placeholder="Enter diagnosis details"
+              value={diagnosis}
+              onChange={(e) => setDiagnosis(e.target.value)}
+              rows={4}
+              required
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? "Saving..." : "Save Medical Record"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend-v2/app/medical-records/components/MedicalRecordList.tsx
+++ b/frontend-v2/app/medical-records/components/MedicalRecordList.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import SyncBadge from "./SyncBadge";
+import { MedicalRecord } from "../lib/indexedDb";
+
+interface MedicalRecordListProps {
+  records: MedicalRecord[];
+}
+
+export default function MedicalRecordList({ records }: MedicalRecordListProps) {
+  if (records.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12">
+          <div className="text-center">
+            <svg
+              className="mx-auto h-12 w-12 text-gray-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              />
+            </svg>
+            <h3 className="mt-4 text-lg font-semibold text-gray-900">No medical records yet</h3>
+            <p className="mt-2 text-sm text-gray-500">
+              Get started by creating a new medical record above.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Medical Records</CardTitle>
+          <CardDescription>
+            {records.length} {records.length === 1 ? "record" : "records"} saved locally
+          </CardDescription>
+        </CardHeader>
+      </Card>
+
+      {records.map((record) => (
+        <Card key={record.id} className="hover:shadow-md transition-shadow">
+          <CardHeader>
+            <div className="flex justify-between items-start">
+              <div className="flex-1">
+                <CardTitle className="text-xl">{record.patientName}</CardTitle>
+                <CardDescription>Age: {record.age} years old</CardDescription>
+              </div>
+              <SyncBadge status={record.syncStatus} />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              <div>
+                <h4 className="text-sm font-semibold text-gray-700 mb-1">Diagnosis</h4>
+                <p className="text-sm text-gray-600 whitespace-pre-wrap">{record.diagnosis}</p>
+              </div>
+              <div className="pt-2 border-t">
+                <p className="text-xs text-gray-500">
+                  Created: {new Date(record.createdAt).toLocaleString()}
+                </p>
+                {record.updatedAt && (
+                  <p className="text-xs text-gray-500">
+                    Updated: {new Date(record.updatedAt).toLocaleString()}
+                  </p>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/frontend-v2/app/medical-records/components/SyncBadge.tsx
+++ b/frontend-v2/app/medical-records/components/SyncBadge.tsx
@@ -1,0 +1,53 @@
+import { Badge } from "@/components/ui/badge";
+
+interface SyncBadgeProps {
+  status: "pending" | "synced";
+}
+
+export default function SyncBadge({ status }: SyncBadgeProps) {
+  if (status === "synced") {
+    return (
+      <Badge variant="default" className="bg-green-500 hover:bg-green-600">
+        <svg
+          className="w-3 h-3 mr-1"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 13l4 4L19 7"
+          />
+        </svg>
+        Synced
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="secondary" className="bg-yellow-100 text-yellow-800 hover:bg-yellow-200">
+      <svg
+        className="w-3 h-3 mr-1 animate-spin"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        />
+      </svg>
+      Pending
+    </Badge>
+  );
+}

--- a/frontend-v2/app/medical-records/lib/indexedDb.ts
+++ b/frontend-v2/app/medical-records/lib/indexedDb.ts
@@ -1,0 +1,131 @@
+// IndexedDB utilities for medical records
+
+export interface MedicalRecord {
+  id?: number;
+  patientName: string;
+  age: number;
+  diagnosis: string;
+  syncStatus: "pending" | "synced";
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DB_NAME = "MedicalRecordsDB";
+const STORE_NAME = "medicalRecords";
+const DB_VERSION = 1;
+
+// Initialize IndexedDB
+export const initDB = (): Promise<IDBDatabase> => {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const objectStore = db.createObjectStore(STORE_NAME, { 
+          keyPath: "id", 
+          autoIncrement: true 
+        });
+        objectStore.createIndex("syncStatus", "syncStatus", { unique: false });
+        objectStore.createIndex("createdAt", "createdAt", { unique: false });
+      }
+    };
+  });
+};
+
+// Add a new medical record
+export const addRecord = async (record: Omit<MedicalRecord, "id">): Promise<number> => {
+  const db = await initDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction([STORE_NAME], "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.add(record);
+
+    request.onsuccess = () => resolve(request.result as number);
+    request.onerror = () => reject(request.error);
+  });
+};
+
+// Get all medical records
+export const getAllRecords = async (): Promise<MedicalRecord[]> => {
+  const db = await initDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction([STORE_NAME], "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.getAll();
+
+    request.onsuccess = () => {
+      const records = request.result as MedicalRecord[];
+      // Sort by most recent first
+      records.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      resolve(records);
+    };
+    request.onerror = () => reject(request.error);
+  });
+};
+
+// Get a single record by ID
+export const getRecord = async (id: number): Promise<MedicalRecord | undefined> => {
+  const db = await initDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction([STORE_NAME], "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(id);
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+};
+
+// Update a medical record
+export const updateRecord = async (record: MedicalRecord): Promise<void> => {
+  const db = await initDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction([STORE_NAME], "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.put(record);
+
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+};
+
+// Update sync status
+export const updateSyncStatus = async (
+  id: number, 
+  syncStatus: "pending" | "synced"
+): Promise<void> => {
+  const record = await getRecord(id);
+  if (record) {
+    record.syncStatus = syncStatus;
+    record.updatedAt = new Date();
+    await updateRecord(record);
+  }
+};
+
+// Delete a medical record
+export const deleteRecord = async (id: number): Promise<void> => {
+  const db = await initDB();
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction([STORE_NAME], "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.delete(id);
+
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+};
+
+// Simulate sync - updates status after delay
+export const simulateSync = async (id: number, delayMs: number = 2500): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(async () => {
+      await updateSyncStatus(id, "synced");
+      resolve();
+    }, delayMs);
+  });
+};

--- a/frontend-v2/app/medical-records/page.tsx
+++ b/frontend-v2/app/medical-records/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import MedicalRecordForm from "./components/MedicalRecordForm";
+import MedicalRecordList from "./components/MedicalRecordList";
+import { MedicalRecord, getAllRecords } from "./lib/indexedDb";
+
+export default function MedicalRecordsPage() {
+  const [records, setRecords] = useState<MedicalRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const loadRecords = async () => {
+    try {
+      const allRecords = await getAllRecords();
+      setRecords(allRecords);
+    } catch (error) {
+      console.error("Error loading records:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadRecords();
+  }, []);
+
+  const handleRecordAdded = () => {
+    loadRecords();
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 py-8">
+        <div className="container mx-auto px-4 max-w-4xl">
+          <div className="flex items-center justify-center py-12">
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900 mx-auto"></div>
+              <p className="mt-4 text-gray-600">Loading medical records...</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4 max-w-4xl">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Medical Records</h1>
+          <p className="text-gray-600">
+            Offline-first medical records management system
+          </p>
+          <div className="mt-2 flex items-center text-sm text-gray-500">
+            <svg
+              className="w-4 h-4 mr-1 text-green-500"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fillRule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                clipRule="evenodd"
+              />
+            </svg>
+            Offline ready - All data stored locally
+          </div>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-1 lg:grid-cols-2">
+          <div>
+            <MedicalRecordForm onRecordAdded={handleRecordAdded} />
+          </div>
+
+          <div>
+            <MedicalRecordList records={records} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implemented an offline-first Medical Records UI using IndexedDB for local storage. This enables creating and viewing medical records without network dependency.

**Includes**

- Medical records page

- Create medical record form

- Records list with sync status

- Offline persistence via IndexedDB

**Notes**

- Frontend-only implementation

- Sync behavior is simulated for future backend integration

**Testing**

- Manual testing

- Verified record creation

- Confirmed persistence across page reloads