### PR TITLE
Add admin dashboard

### DIFF
--- a/frontend-v2/app/Admin/page,tsx
+++ b/frontend-v2/app/Admin/page,tsx
@@ -1,0 +1,452 @@
+'use client';
+
+import React, { useState } from 'react';
+import { LineChart, Line, AreaChart, Area, PieChart, Pie, Cell, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { Menu, X, TrendingUp, TrendingDown, Users, DollarSign, Award, AlertCircle, Download, Settings, FileText, ChevronDown, Layout, UserCheck, Shield } from 'lucide-react';
+import {
+  dashboardStats,
+  donationsOverTime,
+  userGrowthData,
+  rankDistribution,
+  recentActivity,
+  XLM_RATE,
+  DashboardStats,
+  DonationDataPoint,
+  UserGrowthDataPoint,
+  RankDistribution,
+  RecentActivity,
+} from '@/data/admin-mock';
+
+interface NavItem {
+  id: string;
+  label: string;
+  icon: React.ElementType;
+}
+
+interface StatCardProps {
+  title: string;
+  value: string;
+  trend?: number;
+  icon: React.ElementType;
+  subtitle?: string;
+  loading?: boolean;
+}
+
+const AdminDashboard: React.FC = () => {
+  const [isAdmin] = useState(true); // Mock admin check - replace with actual auth
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [activeNav, setActiveNav] = useState('dashboard');
+  const [exportDropdownOpen, setExportDropdownOpen] = useState(false);
+
+  // Access Denied Screen
+  if (!isAdmin) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-lg shadow-lg p-8 max-w-md w-full text-center">
+          <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <Shield className="w-8 h-8 text-red-600" />
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">Access Denied</h1>
+          <p className="text-gray-600 mb-6">
+            You do not have permission to access the admin dashboard.
+          </p>
+          <button className="bg-teal-600 text-white px-6 py-2 rounded-lg hover:bg-teal-700 transition">
+            Return Home
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const navItems: NavItem[] = [
+    { id: 'dashboard', label: 'Dashboard', icon: Layout },
+    { id: 'users', label: 'Users', icon: Users },
+    { id: 'donations', label: 'Donations', icon: DollarSign },
+    { id: 'verifications', label: 'Verifications', icon: UserCheck },
+    { id: 'content', label: 'Content', icon: FileText },
+    { id: 'settings', label: 'Settings', icon: Settings },
+  ];
+
+  // Format donation data for display
+  const formattedDonationData = donationsOverTime.map((item) => ({
+    ...item,
+    date: new Date(item.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+  }));
+
+  // Stat Card Component
+  const StatCard: React.FC<StatCardProps> = ({ title, value, trend, icon: Icon, subtitle, loading }) => (
+    <div className="bg-white rounded-lg shadow p-6">
+      {loading ? (
+        <div className="animate-pulse">
+          <div className="h-4 bg-gray-200 rounded w-1/2 mb-4"></div>
+          <div className="h-8 bg-gray-200 rounded w-3/4 mb-2"></div>
+          <div className="h-3 bg-gray-200 rounded w-1/2"></div>
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center justify-between mb-4">
+            <p className="text-gray-600 text-sm font-medium">{title}</p>
+            <div className="w-10 h-10 bg-teal-100 rounded-lg flex items-center justify-center">
+              <Icon className="w-5 h-5 text-teal-600" />
+            </div>
+          </div>
+          <h3 className="text-3xl font-bold text-gray-900 mb-2">{value}</h3>
+          {subtitle && <p className="text-sm text-gray-500 mb-2">{subtitle}</p>}
+          {trend !== undefined && (
+            <div className="flex items-center">
+              {trend > 0 ? (
+                <TrendingUp className="w-4 h-4 text-green-600 mr-1" />
+              ) : (
+                <TrendingDown className="w-4 h-4 text-red-600 mr-1" />
+              )}
+              <span className={`text-sm font-medium ${trend > 0 ? 'text-green-600' : 'text-red-600'}`}>
+                {Math.abs(trend)}% from last month
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Sidebar - Desktop */}
+      <aside
+        className={`fixed left-0 top-0 h-full w-64 bg-white shadow-lg transform transition-transform duration-300 z-30 ${
+          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
+        } lg:translate-x-0`}
+      >
+        <div className="p-6 border-b">
+          <h1 className="text-2xl font-bold text-teal-600">Admin Panel</h1>
+        </div>
+        <nav className="p-4">
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <button
+                key={item.id}
+                onClick={() => setActiveNav(item.id)}
+                className={`w-full flex items-center px-4 py-3 rounded-lg mb-2 transition ${
+                  activeNav === item.id
+                    ? 'bg-teal-50 text-teal-600 font-medium'
+                    : 'text-gray-600 hover:bg-gray-50'
+                }`}
+              >
+                <Icon className="w-5 h-5 mr-3" />
+                {item.label}
+              </button>
+            );
+          })}
+        </nav>
+      </aside>
+
+      {/* Mobile Overlay */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-50 z-20 lg:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      {/* Main Content */}
+      <div className="lg:ml-64">
+        {/* Top Bar */}
+        <header className="bg-white shadow-sm sticky top-0 z-10">
+          <div className="flex items-center justify-between px-4 py-4">
+            <div className="flex items-center">
+              <button
+                className="lg:hidden mr-4"
+                onClick={() => setSidebarOpen(!sidebarOpen)}
+                aria-label="Toggle sidebar"
+              >
+                {sidebarOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+              </button>
+              <h2 className="text-xl font-semibold text-gray-900">Dashboard</h2>
+            </div>
+            <div className="flex items-center space-x-4">
+              <div className="w-10 h-10 bg-teal-600 rounded-full flex items-center justify-center text-white font-semibold">
+                A
+              </div>
+            </div>
+          </div>
+        </header>
+
+        {/* Dashboard Content */}
+        <main className="p-4 md:p-6 lg:p-8">
+          {/* Stats Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+            <StatCard
+              title="Total Users"
+              value={dashboardStats.totalUsers.toLocaleString()}
+              trend={dashboardStats.trends.users}
+              icon={Users}
+              loading={loading}
+            />
+            <StatCard
+              title="Total Donations"
+              value={`$${dashboardStats.totalDonations.toLocaleString()}`}
+              subtitle={`${(dashboardStats.totalDonations / XLM_RATE).toLocaleString()} XLM`}
+              trend={dashboardStats.trends.donations}
+              icon={DollarSign}
+              loading={loading}
+            />
+            <StatCard
+              title="Active Helpers"
+              value={dashboardStats.activeHelpers.toLocaleString()}
+              trend={dashboardStats.trends.helpers}
+              icon={Award}
+              loading={loading}
+            />
+            <div className="bg-white rounded-lg shadow p-6">
+              <div className="flex items-center justify-between mb-4">
+                <p className="text-gray-600 text-sm font-medium">Pending Verifications</p>
+                <div className="w-10 h-10 bg-orange-100 rounded-lg flex items-center justify-center">
+                  <AlertCircle className="w-5 h-5 text-orange-600" />
+                </div>
+              </div>
+              <h3 className="text-3xl font-bold text-gray-900 mb-4">
+                {dashboardStats.pendingVerifications}
+              </h3>
+              <button className="w-full bg-teal-600 text-white py-2 rounded-lg hover:bg-teal-700 transition text-sm font-medium">
+                Review Now
+              </button>
+            </div>
+          </div>
+
+          {/* Charts Section */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+            {/* Donations Over Time */}
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4">Donations Over Time</h3>
+              <div role="img" aria-label="Line chart showing donations over the last 30 days">
+                <ResponsiveContainer width="100%" height={300}>
+                  <LineChart data={formattedDonationData}>
+                    <defs>
+                      <linearGradient id="donationGradient" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#14b8a6" stopOpacity={0.3} />
+                        <stop offset="95%" stopColor="#14b8a6" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                    <XAxis dataKey="date" tick={{ fontSize: 12 }} interval="preserveStartEnd" />
+                    <YAxis tick={{ fontSize: 12 }} />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: 'white',
+                        border: '1px solid #e5e7eb',
+                        borderRadius: '8px',
+                      }}
+                      formatter={(value: number) => [`$${value.toLocaleString()}`, 'Amount']}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="amount"
+                      stroke="#14b8a6"
+                      strokeWidth={2}
+                      fill="url(#donationGradient)"
+                      dot={{ fill: '#14b8a6', r: 3 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+
+            {/* User Growth */}
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4">User Growth</h3>
+              <div role="img" aria-label="Area chart showing new and returning users over 6 months">
+                <ResponsiveContainer width="100%" height={300}>
+                  <AreaChart data={userGrowthData}>
+                    <defs>
+                      <linearGradient id="newUsers" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#14b8a6" stopOpacity={0.8} />
+                        <stop offset="95%" stopColor="#14b8a6" stopOpacity={0.1} />
+                      </linearGradient>
+                      <linearGradient id="returningUsers" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="5%" stopColor="#0891b2" stopOpacity={0.8} />
+                        <stop offset="95%" stopColor="#0891b2" stopOpacity={0.1} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                    <XAxis dataKey="month" tick={{ fontSize: 12 }} />
+                    <YAxis tick={{ fontSize: 12 }} />
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: 'white',
+                        border: '1px solid #e5e7eb',
+                        borderRadius: '8px',
+                      }}
+                    />
+                    <Legend />
+                    <Area
+                      type="monotone"
+                      dataKey="newUsers"
+                      stackId="1"
+                      stroke="#14b8a6"
+                      fill="url(#newUsers)"
+                      name="New Users"
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="returningUsers"
+                      stackId="1"
+                      stroke="#0891b2"
+                      fill="url(#returningUsers)"
+                      name="Returning Users"
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
+            </div>
+          </div>
+
+          {/* Bottom Section */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            {/* Helper Ranks Distribution */}
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4">
+                Helper Ranks Distribution
+              </h3>
+              <div role="img" aria-label="Pie chart showing distribution of helper ranks">
+                <ResponsiveContainer width="100%" height={300}>
+                  <PieChart>
+                    <Pie
+                      data={rankDistribution}
+                      cx="50%"
+                      cy="50%"
+                      labelLine={false}
+                      label={({ percentage }) => `${percentage}%`}
+                      outerRadius={80}
+                      dataKey="count"
+                    >
+                      {rankDistribution.map((entry, index) => (
+                        <Cell key={`cell-${index}`} fill={entry.fill} />
+                      ))}
+                    </Pie>
+                    <Tooltip
+                      contentStyle={{
+                        backgroundColor: 'white',
+                        border: '1px solid #e5e7eb',
+                        borderRadius: '8px',
+                      }}
+                      formatter={(value: number, name: string, props: any) => [
+                        value,
+                        props.payload.rank,
+                      ]}
+                    />
+                  </PieChart>
+                </ResponsiveContainer>
+              </div>
+              <div className="mt-4 space-y-2">
+                {rankDistribution.map((item) => (
+                  <div key={item.rank} className="flex items-center justify-between text-sm">
+                    <div className="flex items-center">
+                      <div
+                        className="w-3 h-3 rounded-full mr-2"
+                        style={{ backgroundColor: item.fill }}
+                      ></div>
+                      <span className="text-gray-600">{item.rank}</span>
+                    </div>
+                    <span className="font-medium text-gray-900">{item.count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Recent Activity */}
+            <div className="bg-white rounded-lg shadow p-6 lg:col-span-2">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-semibold text-gray-900">Recent Activity</h3>
+                <button className="text-teal-600 hover:text-teal-700 text-sm font-medium">
+                  View all
+                </button>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full" role="table" aria-label="Recent activity table">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left py-3 px-2 text-sm font-medium text-gray-600">
+                        User
+                      </th>
+                      <th className="text-left py-3 px-2 text-sm font-medium text-gray-600">
+                        Action
+                      </th>
+                      <th className="text-left py-3 px-2 text-sm font-medium text-gray-600">
+                        Amount
+                      </th>
+                      <th className="text-left py-3 px-2 text-sm font-medium text-gray-600">
+                        Date
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {recentActivity.map((activity) => (
+                      <tr key={activity.id} className="border-b hover:bg-gray-50">
+                        <td className="py-3 px-2 text-sm text-gray-900">{activity.user}</td>
+                        <td className="py-3 px-2 text-sm text-gray-600">{activity.action}</td>
+                        <td className="py-3 px-2 text-sm text-gray-900">
+                          {activity.amount ? `$${activity.amount}` : '-'}
+                        </td>
+                        <td className="py-3 px-2 text-sm text-gray-500">{activity.date}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          {/* Quick Actions Panel */}
+          <div className="bg-white rounded-lg shadow p-6 mt-6">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+              <button className="flex items-center justify-between px-4 py-3 border-2 border-teal-600 text-teal-600 rounded-lg hover:bg-teal-50 transition">
+                <span className="font-medium">Review Verifications</span>
+                <span className="bg-teal-600 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center">
+                  {dashboardStats.pendingVerifications}
+                </span>
+              </button>
+
+              <div className="relative">
+                <button
+                  onClick={() => setExportDropdownOpen(!exportDropdownOpen)}
+                  className="w-full flex items-center justify-between px-4 py-3 border-2 border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition"
+                >
+                  <span className="font-medium flex items-center">
+                    <Download className="w-4 h-4 mr-2" />
+                    Export Reports
+                  </span>
+                  <ChevronDown className="w-4 h-4" />
+                </button>
+                {exportDropdownOpen && (
+                  <div className="absolute top-full left-0 right-0 mt-2 bg-white border rounded-lg shadow-lg z-10">
+                    <button className="w-full text-left px-4 py-2 hover:bg-gray-50 text-sm">
+                      Export as CSV
+                    </button>
+                    <button className="w-full text-left px-4 py-2 hover:bg-gray-50 text-sm">
+                      Export as PDF
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              <button className="flex items-center justify-center px-4 py-3 border-2 border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition">
+                <Users className="w-4 h-4 mr-2" />
+                <span className="font-medium">Manage Users</span>
+              </button>
+
+              <button className="flex items-center justify-center px-4 py-3 border-2 border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition">
+                <Settings className="w-4 h-4 mr-2" />
+                <span className="font-medium">Settings</span>
+              </button>
+            </div>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/frontend-v2/data/Amin/mock.ts
+++ b/frontend-v2/data/Amin/mock.ts
@@ -1,0 +1,168 @@
+// /frontend-v2/data/admin-mock.ts
+
+export interface DashboardStats {
+  totalUsers: number;
+  totalDonations: number;
+  activeHelpers: number;
+  pendingVerifications: number;
+  trends: {
+    users: number;
+    donations: number;
+    helpers: number;
+  };
+}
+
+export interface DonationDataPoint {
+  date: string;
+  amount: number;
+}
+
+export interface UserGrowthDataPoint {
+  month: string;
+  newUsers: number;
+  returningUsers: number;
+}
+
+export interface RankDistribution {
+  rank: string;
+  count: number;
+  percentage: number;
+  fill: string;
+}
+
+export interface RecentActivity {
+  id: string;
+  user: string;
+  action: string;
+  amount?: number;
+  date: string;
+  timestamp: number;
+}
+
+export const dashboardStats: DashboardStats = {
+  totalUsers: 12458,
+  totalDonations: 245678.50,
+  activeHelpers: 3247,
+  pendingVerifications: 23,
+  trends: {
+    users: 12,
+    donations: 18.5,
+    helpers: 8.3,
+  },
+};
+
+// Last 30 days donation data
+export const donationsOverTime: DonationDataPoint[] = Array.from({ length: 30 }, (_, i) => {
+  const date = new Date();
+  date.setDate(date.getDate() - (29 - i));
+  return {
+    date: date.toISOString().split('T')[0],
+    amount: Math.floor(Math.random() * 5000) + 3000,
+  };
+});
+
+// Last 6 months user growth
+export const userGrowthData: UserGrowthDataPoint[] = [
+  { month: 'Aug', newUsers: 1245, returningUsers: 890 },
+  { month: 'Sep', newUsers: 1567, returningUsers: 1123 },
+  { month: 'Oct', newUsers: 1834, returningUsers: 1456 },
+  { month: 'Nov', newUsers: 2012, returningUsers: 1678 },
+  { month: 'Dec', newUsers: 2345, returningUsers: 1890 },
+  { month: 'Jan', newUsers: 2678, returningUsers: 2123 },
+];
+
+// Helper ranks distribution
+export const rankDistribution: RankDistribution[] = [
+  { rank: 'Bronze', count: 1247, percentage: 38.4, fill: '#CD7F32' },
+  { rank: 'Silver', count: 976, percentage: 30.1, fill: '#C0C0C0' },
+  { rank: 'Gold', count: 542, percentage: 16.7, fill: '#FFD700' },
+  { rank: 'Platinum', count: 312, percentage: 9.6, fill: '#E5E4E2' },
+  { rank: 'Diamond', count: 134, percentage: 4.1, fill: '#B9F2FF' },
+  { rank: 'Elite', count: 36, percentage: 1.1, fill: '#9370DB' },
+];
+
+// Recent activity
+export const recentActivity: RecentActivity[] = [
+  {
+    id: '1',
+    user: 'Sarah Johnson',
+    action: 'Donated to Climate Action',
+    amount: 250,
+    date: '2 hours ago',
+    timestamp: Date.now() - 7200000,
+  },
+  {
+    id: '2',
+    user: 'Michael Chen',
+    action: 'Verified as Helper',
+    date: '3 hours ago',
+    timestamp: Date.now() - 10800000,
+  },
+  {
+    id: '3',
+    user: 'Emma Williams',
+    action: 'Donated to Education Fund',
+    amount: 500,
+    date: '5 hours ago',
+    timestamp: Date.now() - 18000000,
+  },
+  {
+    id: '4',
+    user: 'James Rodriguez',
+    action: 'Updated profile',
+    date: '6 hours ago',
+    timestamp: Date.now() - 21600000,
+  },
+  {
+    id: '5',
+    user: 'Olivia Martinez',
+    action: 'Donated to Healthcare',
+    amount: 150,
+    date: '8 hours ago',
+    timestamp: Date.now() - 28800000,
+  },
+  {
+    id: '6',
+    user: 'William Brown',
+    action: 'Achieved Gold Rank',
+    date: '10 hours ago',
+    timestamp: Date.now() - 36000000,
+  },
+  {
+    id: '7',
+    user: 'Sophia Davis',
+    action: 'Donated to Food Bank',
+    amount: 75,
+    date: '12 hours ago',
+    timestamp: Date.now() - 43200000,
+  },
+  {
+    id: '8',
+    user: 'Liam Wilson',
+    action: 'Registered as Helper',
+    date: '14 hours ago',
+    timestamp: Date.now() - 50400000,
+  },
+  {
+    id: '9',
+    user: 'Ava Taylor',
+    action: 'Donated to Animal Shelter',
+    amount: 300,
+    date: '16 hours ago',
+    timestamp: Date.now() - 57600000,
+  },
+  {
+    id: '10',
+    user: 'Noah Anderson',
+    action: 'Completed verification',
+    date: '18 hours ago',
+    timestamp: Date.now() - 64800000,
+  },
+].sort((a, b) => b.timestamp - a.timestamp);
+
+// XLM conversion rate (mock)
+export const XLM_RATE = 0.12; // 1 XLM = $0.12
+
+export const calculateXLMEquivalent = (usdAmount: number): number => {
+  return parseFloat((usdAmount / XLM_RATE).toFixed(2));
+};


### PR DESCRIPTION


This PR adds a basic Admin Dashboard page.
The `/admin` route is protected with a mock admin check.
Dashboard components are separated for clarity, charts use Recharts, and all data is loaded from mock data files.
No backend changes were made.


### **What was added**

* Admin dashboard page (`/admin`)
* Mock admin access check
* Reusable dashboard components
* Charts built with Recharts
* Mock data stored in `admin-mock.ts`


### **Notes**

* Frontend only
* No API calls
* Mock data used as instructed

