### PR TITLE
Implemented the health task detail page and /tasks listing

### DIFF
--- a/app/tasks/[id]/page.tsx
+++ b/app/tasks/[id]/page.tsx
@@ -1,0 +1,30 @@
+import Navigation from '@/components/navigation'
+import Footer from '@/components/footer'
+import { notFound } from 'next/navigation'
+
+import { getTaskById } from '@/lib/mock/tasks'
+import { TaskDetailPage } from '@/components/tasks/TaskDetailPage'
+
+interface TaskPageProps {
+  params: Promise<{
+    id: string
+  }>
+}
+
+export default async function TaskPage({ params }: TaskPageProps) {
+  const { id } = await params
+  const task = getTaskById(id)
+
+  if (!task) {
+    notFound()
+  }
+
+  return (
+    <>
+      <Navigation />
+      <TaskDetailPage task={task} />
+      <Footer />
+    </>
+  )
+}
+

--- a/app/tasks/page.tsx
+++ b/app/tasks/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import Navigation from "@/components/navigation";
+import Footer from "@/components/footer";
+import { HealthTaskCard } from "@/components/tasks";
+import { mockTasks } from "@/lib/mock/tasks";
+
+export default function TasksPage() {
+  const router = useRouter();
+
+  return (
+    <>
+      <Navigation />
+
+      <main className="pt-28 pb-20 px-4 sm:px-6 bg-cream min-h-screen">
+        <div className="max-w-5xl mx-auto space-y-8">
+          <header className="space-y-3">
+            <p className="text-xs font-semibold tracking-[0.2em] uppercase text-terra/80">
+              Daily Health Tasks
+            </p>
+            <h1 className="font-serif text-3xl sm:text-4xl font-bold text-earth tracking-tight">
+              Earn XLM for caring for your health
+            </h1>
+            <p className="text-sm sm:text-base text-muted max-w-2xl">
+              Choose a task that fits your day, follow the simple health steps,
+              and complete it honestly to unlock your Stellar Lumens (XLM)
+              reward.
+            </p>
+          </header>
+
+          <section className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
+            {mockTasks.map((task) => (
+              <HealthTaskCard
+                key={task.id}
+                title={task.title}
+                reward={task.rewardXLM}
+                category={task.category}
+                status="available"
+                onClaim={() => router.push(`/tasks/${task.id}`)}
+              />
+            ))}
+          </section>
+        </div>
+      </main>
+
+      <Footer />
+    </>
+  );
+}

--- a/components/tasks/HealthTaskCard.tsx
+++ b/components/tasks/HealthTaskCard.tsx
@@ -1,38 +1,22 @@
 'use client'
 
 import * as React from 'react'
-import { Check, Sparkles } from 'lucide-react'
+import { Activity, Check, Coins, Droplets, Footprints, Leaf } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
 export type HealthTaskStatus = 'available' | 'completed' | 'claimed'
 
 export interface HealthTaskCardProps {
-  /** Task title — e.g. "Complete daily hydration check" */
   title: string
-  /** XLM reward amount — e.g. 0.5 */
   reward: number
-  /** Category label — e.g. "Nutrition", "Exercise", "Mental Health" */
   category: string
-  /** Current task status */
   status: HealthTaskStatus
-  /** Emoji or image path used as the task icon */
-  icon: string
-  /** Callback fired when the user clicks the claim button */
   onClaim?: () => void
-  /** Additional class names forwarded to the root element */
   className?: string
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 const CATEGORY_COLORS: Record<string, string> = {
   Nutrition: 'bg-[#5A7A4A]/10 text-[#5A7A4A]',
@@ -44,42 +28,35 @@ function getCategoryColor(category: string): string {
   return CATEGORY_COLORS[category] ?? 'bg-[#8A6040]/10 text-[#8A6040]'
 }
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+function getTaskIcon(title: string, category: string) {
+  const lowerTitle = title.toLowerCase()
 
-/**
- * A reusable card that represents a single health task a user can complete to
- * earn XLM coins. Supports three visual states: **available**, **completed**,
- * and **claimed**.
- *
- * @example
- * ```tsx
- * <HealthTaskCard
- *   title="Complete daily hydration check"
- *   reward={0.5}
- *   category="Nutrition"
- *   status="available"
- *   icon="💧"
- *   onClaim={() => console.log('claimed!')}
- * />
- * ```
- */
+  if (lowerTitle.includes('hydration') || lowerTitle.includes('water')) {
+    return <Droplets className="h-6 w-6 text-[#C05A2B]" aria-hidden="true" />
+  }
+
+  if (lowerTitle.includes('walk') || category === 'Exercise') {
+    return <Footprints className="h-6 w-6 text-[#C05A2B]" aria-hidden="true" />
+  }
+
+  if (category === 'Traditional Medicine') {
+    return <Leaf className="h-6 w-6 text-[#C05A2B]" aria-hidden="true" />
+  }
+
+  return <Activity className="h-6 w-6 text-[#C05A2B]" aria-hidden="true" />
+}
+
 export function HealthTaskCard({
   title,
   reward,
   category,
   status,
-  icon,
   onClaim,
   className,
 }: HealthTaskCardProps) {
   const isAvailable = status === 'available'
   const isCompleted = status === 'completed'
   const isClaimed = status === 'claimed'
-
-  // Determine if the icon is an image path or an emoji
-  const isImageIcon = icon.startsWith('/') || icon.startsWith('http')
 
   return (
     <div
@@ -116,16 +93,7 @@ export function HealthTaskCard({
             isClaimed && 'bg-[#F0C050]/15',
           )}
         >
-          {isImageIcon ? (
-            <img
-              src={icon}
-              alt=""
-              className="h-7 w-7 object-contain"
-              aria-hidden="true"
-            />
-          ) : (
-            <span aria-hidden="true">{icon}</span>
-          )}
+          {getTaskIcon(title, category)}
 
           {/* Completed / claimed checkmark overlay */}
           {(isCompleted || isClaimed) && (
@@ -173,7 +141,7 @@ export function HealthTaskCard({
               'bg-[#F0C050]/15 text-[#B88A20]',
           )}
         >
-          <Sparkles className="h-3 w-3" />
+          <Coins className="h-3 w-3" />
           {reward} XLM
         </Badge>
       </div>

--- a/components/tasks/TaskDetailPage.tsx
+++ b/components/tasks/TaskDetailPage.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Activity,
+  ArrowLeft,
+  Camera,
+  CheckCircle2,
+  ClipboardList,
+  Coins,
+  Droplets,
+  FileImage,
+  Footprints,
+  Leaf,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { HealthTask } from "@/lib/mock/tasks";
+
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+
+interface TaskDetailPageProps {
+  task: HealthTask;
+}
+
+function getTaskIcon(task: HealthTask) {
+  const lowerTitle = task.title.toLowerCase();
+
+  if (lowerTitle.includes("hydration") || lowerTitle.includes("water")) {
+    return <Droplets className="h-7 w-7 text-terra" aria-hidden="true" />;
+  }
+
+  if (lowerTitle.includes("walk") || task.category === "Exercise") {
+    return <Footprints className="h-7 w-7 text-terra" aria-hidden="true" />;
+  }
+
+  if (task.category === "Traditional Medicine" || task.isTraditional) {
+    return <Leaf className="h-7 w-7 text-terra" aria-hidden="true" />;
+  }
+
+  return <Activity className="h-7 w-7 text-terra" aria-hidden="true" />;
+}
+
+export function TaskDetailPage({ task }: TaskDetailPageProps) {
+  const router = useRouter();
+
+  const [isCompleted, setIsCompleted] = useState(false);
+  const [isMarkingComplete, setIsMarkingComplete] = useState(false);
+  const [isSubmittingProof, setIsSubmittingProof] = useState(false);
+
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  const handleBack = () => {
+    router.back();
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = event.target.files?.[0];
+
+    setUploadError(null);
+
+    if (!selectedFile) {
+      setFile(null);
+      setPreviewUrl(null);
+      return;
+    }
+
+    const isValidType =
+      selectedFile.type === "image/jpeg" || selectedFile.type === "image/png";
+    if (!isValidType) {
+      setUploadError("Please upload a JPG or PNG image.");
+      setFile(null);
+      setPreviewUrl(null);
+      return;
+    }
+
+    if (selectedFile.size > MAX_FILE_SIZE_BYTES) {
+      setUploadError("Image must be 5MB or smaller.");
+      setFile(null);
+      setPreviewUrl(null);
+      return;
+    }
+
+    const url = URL.createObjectURL(selectedFile);
+    setFile(selectedFile);
+    setPreviewUrl(url);
+  };
+
+  const handleSelfReportComplete = async () => {
+    if (isCompleted || isMarkingComplete) return;
+
+    setIsMarkingComplete(true);
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    setIsMarkingComplete(false);
+    setIsCompleted(true);
+  };
+
+  const handleSubmitProof = async () => {
+    if (isCompleted || isSubmittingProof) return;
+
+    if (!file) {
+      setUploadError("Please upload a JPG or PNG image before submitting.");
+      return;
+    }
+
+    setUploadError(null);
+    setIsSubmittingProof(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 900));
+
+    setIsSubmittingProof(false);
+    setIsCompleted(true);
+  };
+
+  const proofTypeLabel =
+    task.proofType === "photo" ? "Photo required" : "Self report";
+
+  const ProofIcon = task.proofType === "photo" ? Camera : ClipboardList;
+
+  const isPhotoTask = task.proofType === "photo";
+
+  return (
+    <main className="min-h-screen bg-cream">
+      <div className="pt-28 pb-16 px-4 sm:px-6">
+        <div className="max-w-4xl mx-auto space-y-6">
+          <button
+            type="button"
+            onClick={handleBack}
+            className="inline-flex items-center gap-2 text-sm font-medium text-muted hover:text-earth transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            <span>Back to Tasks</span>
+          </button>
+
+          <section className="rounded-3xl border border-terra/10 bg-white px-5 py-6 sm:px-8 sm:py-7 shadow-sm">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-5">
+              <div className="flex items-center justify-center h-16 w-16 rounded-2xl bg-terra/10 shrink-0">
+                {getTaskIcon(task)}
+              </div>
+
+              <div className="flex-1 min-w-0 space-y-2">
+                <h1 className="font-serif text-2xl sm:text-3xl font-bold text-earth leading-tight">
+                  {task.title}
+                </h1>
+                <div className="flex flex-wrap items-center gap-2.5">
+                  <Badge
+                    className={cn(
+                      "text-xs font-semibold rounded-full px-3 py-1",
+                      "bg-terra/10 text-terra",
+                    )}
+                  >
+                    {task.category}
+                  </Badge>
+
+                  <Badge
+                    className={cn(
+                      "inline-flex items-center gap-1.5 rounded-full border-0 px-3 py-1 text-xs font-bold tabular-nums",
+                      "bg-gold/15 text-gold",
+                    )}
+                  >
+                    <Coins className="h-3.5 w-3.5" />
+                    {task.rewardXLM} XLM
+                  </Badge>
+
+                  <Badge
+                    variant="outline"
+                    className="inline-flex items-center gap-1.5 rounded-full border-earth/10 bg-cream text-xs font-medium text-earth"
+                  >
+                    <ProofIcon className="h-3.5 w-3.5 text-terra" />
+                    {proofTypeLabel}
+                  </Badge>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="grid gap-4 sm:grid-cols-[minmax(0,3fr)]">
+            <div className="rounded-3xl border border-terra/10 bg-[#FFFDF5] p-5 sm:p-6">
+              <h2 className="mb-2 text-sm font-semibold tracking-wide text-terra uppercase">
+                Why this matters
+              </h2>
+              <p className="text-sm leading-relaxed text-earth/80">
+                {task.whyItMatters}
+              </p>
+            </div>
+
+            {task.isTraditional && (
+              <div className="rounded-3xl border border-terra/20 bg-cream p-4 flex items-start gap-3">
+                <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-terra/10 text-terra">
+                  <Leaf className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-earth">
+                    This task is rooted in {task.culture ?? "African"} healing
+                    tradition.
+                  </p>
+                  <p className="text-xs text-muted">
+                    You&apos;re helping keep traditional knowledge alive while
+                    using simple, safe tracking in the app.
+                  </p>
+                </div>
+              </div>
+            )}
+          </section>
+
+          <section className="rounded-3xl border border-terra/10 bg-white p-5 sm:p-6 space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold tracking-wide text-terra uppercase">
+                Step-by-step instructions
+              </h2>
+              <Badge className="bg-terra/10 text-terra text-[11px] rounded-full px-2.5 py-1">
+                {task.steps.length} steps
+              </Badge>
+            </div>
+
+            <ol className="space-y-3">
+              {task.steps.map((step, index) => (
+                <li
+                  key={step.title}
+                  className="flex gap-3 rounded-2xl bg-cream/80 p-3.5"
+                >
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-earth text-cream text-xs font-semibold">
+                    {index + 1}
+                  </div>
+                  <div className="flex-1 space-y-1.5">
+                    <p className="text-sm font-semibold text-earth">
+                      {step.title}
+                    </p>
+                    {step.description && (
+                      <p className="text-xs leading-relaxed text-muted">
+                        {step.description}
+                      </p>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className="rounded-3xl border border-terra/10 bg-white p-5 sm:p-6 space-y-5">
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <div>
+                <h2 className="text-sm font-semibold tracking-wide text-terra uppercase">
+                  Complete this task
+                </h2>
+                <p className="mt-1 text-xs text-muted">
+                  {isPhotoTask
+                    ? "Upload a clear photo before submitting your completion."
+                    : "Confirm you have completed the steps honestly to earn your reward."}
+                </p>
+              </div>
+
+              <Badge className="bg-gold/10 text-gold text-[11px] rounded-full px-2.5 py-1 flex items-center gap-1.5">
+                <Coins className="h-3.5 w-3.5" />+{task.rewardXLM} XLM
+              </Badge>
+            </div>
+
+            {isPhotoTask && (
+              <div className="space-y-3">
+                <div className="flex flex-col sm:flex-row gap-4 sm:items-center">
+                  <label className="flex-1">
+                    <span className="sr-only">Upload photo proof</span>
+                    <div className="flex cursor-pointer items-center justify-between gap-3 rounded-2xl border border-dashed border-terra/30 bg-cream/80 px-4 py-3 hover:border-terra/60 transition-colors">
+                      <div className="flex items-center gap-3">
+                        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-terra/10 text-terra">
+                          <Camera className="h-5 w-5" />
+                        </div>
+                        <div>
+                          <p className="text-xs font-semibold text-earth">
+                            Upload photo proof
+                          </p>
+                          <p className="text-[11px] text-muted">
+                            JPG or PNG, up to 5MB
+                          </p>
+                        </div>
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className="text-[11px] border-terra/30 bg-white"
+                      >
+                        Choose file
+                      </Badge>
+                    </div>
+                    <input
+                      type="file"
+                      accept="image/jpeg,image/png"
+                      onChange={handleFileChange}
+                      className="sr-only"
+                      disabled={isCompleted}
+                    />
+                  </label>
+                </div>
+
+                {uploadError && (
+                  <p className="text-xs font-medium text-red-600">
+                    {uploadError}
+                  </p>
+                )}
+
+                {previewUrl && (
+                  <div className="mt-2 flex">
+                    <div className="inline-flex flex-col items-center rounded-2xl border border-terra/15 bg-cream/90 p-3 sm:p-4">
+                      <div className="relative">
+                        <img
+                          src={previewUrl}
+                          alt="Photo preview"
+                          className="h-20 w-20 sm:h-24 sm:w-24 rounded-xl object-cover border border-terra/20"
+                        />
+                        <div className="absolute -top-2 -left-2 flex h-7 w-7 items-center justify-center rounded-full bg-earth/90 text-cream shadow">
+                          <FileImage className="h-4 w-4" />
+                        </div>
+                      </div>
+                      <p className="mt-2 max-w-[8.5rem] truncate text-[11px] font-medium text-earth text-center">
+                        {file?.name}
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-between">
+              {isPhotoTask ? (
+                <Button
+                  type="button"
+                  onClick={handleSubmitProof}
+                  disabled={isCompleted || isSubmittingProof}
+                  className="w-full sm:w-auto rounded-2xl bg-terra text-white text-sm font-semibold hover:bg-earth transition-colors disabled:opacity-70"
+                >
+                  {isCompleted
+                    ? "Task completed"
+                    : isSubmittingProof
+                      ? "Submitting..."
+                      : "Submit photo & complete"}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  onClick={handleSelfReportComplete}
+                  disabled={isCompleted || isMarkingComplete}
+                  className="w-full sm:w-auto rounded-2xl bg-terra text-white text-sm font-semibold hover:bg-earth transition-colors disabled:opacity-70"
+                >
+                  {isCompleted
+                    ? "Task completed"
+                    : isMarkingComplete
+                      ? "Marking complete..."
+                      : "Mark Complete"}
+                </Button>
+              )}
+
+              <p className="text-[11px] text-muted max-w-xs">
+                By completing this task, you confirm the information you provide
+                is honest and based on your real behaviour.
+              </p>
+            </div>
+
+            {isCompleted && (
+              <div className="mt-4 rounded-2xl border border-gold/40 bg-gold/10 px-4 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-3">
+                  <div className="relative h-10 w-10">
+                    <div className="absolute inset-0 rounded-full bg-gold/30 blur-md" />
+                    <div className="relative flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-gold to-amber-400 shadow-lg animate-bounce">
+                      <Coins className="h-5 w-5 text-earth" />
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-sm font-semibold text-earth">
+                      You earned {task.rewardXLM} XLM
+                    </p>
+                    <p className="text-[11px] text-earth/80">
+                      Your reward will appear in your XLM balance shortly.
+                    </p>
+                  </div>
+                </div>
+
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="rounded-full border-gold/60 text-gold hover:bg-gold/10 text-xs font-semibold"
+                  onClick={() => router.push("/services/xlm-rewards")}
+                >
+                  <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
+                  View Reward
+                </Button>
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/lib/mock/tasks.ts
+++ b/lib/mock/tasks.ts
@@ -1,0 +1,120 @@
+export type TaskProofType = "self-report" | "photo";
+
+export interface HealthTask {
+  id: string;
+  title: string;
+  category: string;
+  rewardXLM: number;
+  whyItMatters: string;
+  steps: {
+    title: string;
+    description?: string;
+  }[];
+  proofType: TaskProofType;
+  isTraditional: boolean;
+  culture?: string;
+}
+
+export const mockTasks: HealthTask[] = [
+  {
+    id: "hydration-check",
+    title: "Daily hydration check",
+    category: "Nutrition",
+    rewardXLM: 5,
+    whyItMatters:
+      "Drinking enough water helps your heart, joints, and kidneys work well. When you are low on fluids you can feel tired, get headaches, and find it harder to focus.",
+    steps: [
+      {
+        title: "Fill your water bottle",
+        description:
+          "Start the day with a full bottle or jug of clean drinking water so you can see how much you drink.",
+      },
+      {
+        title: "Drink small amounts often",
+        description:
+          "Take a few sips every hour instead of waiting until you feel very thirsty.",
+      },
+      {
+        title: "Check your urine colour",
+        description:
+          "Aim for pale yellow. Dark yellow or brown urine can be a sign that you need more water.",
+      },
+      {
+        title: "Log your hydration",
+        description:
+          "Once you reach your daily water goal, add a short note or tick in your log, then mark this task as complete.",
+      },
+    ],
+    proofType: "self-report",
+    isTraditional: false,
+  },
+  {
+    id: "neighbourhood-walk-photo",
+    title: "20 minute neighbourhood walk",
+    category: "Exercise",
+    rewardXLM: 8,
+    whyItMatters:
+      "Regular walking improves blood flow, helps with weight control, and can lift your mood. Around 20 minutes a day can lower your risk of heart disease and type 2 diabetes.",
+    steps: [
+      {
+        title: "Choose a safe route",
+        description:
+          "Pick a path that feels safe and familiar, for example your compound, street, or local market area.",
+      },
+      {
+        title: "Warm up your joints",
+        description:
+          "Spend 2 to 3 minutes stretching your ankles, knees, and hips before you start walking.",
+      },
+      {
+        title: "Walk for 20 minutes",
+        description:
+          "Walk at a pace that makes you slightly out of breath but still able to talk. Slow down or rest if your body asks for it.",
+      },
+      {
+        title: "Take a quick photo",
+        description:
+          "Take a clear photo during or right after your walk, such as your street, your shoes, or the view.",
+      },
+    ],
+    proofType: "photo",
+    isTraditional: false,
+  },
+  {
+    id: "traditional-remedy-log",
+    title: "Traditional remedy reflection log",
+    category: "Traditional Medicine",
+    rewardXLM: 10,
+    whyItMatters:
+      "Writing down how a traditional remedy affects you makes it easier to see what really helps. It also lowers the chance of using too much or mixing things that do not go well together.",
+    steps: [
+      {
+        title: "Choose one remedy to reflect on",
+        description:
+          "Pick one remedy you recently used, such as a herbal tea, tonic, or mixture.",
+      },
+      {
+        title: "Note what you used it for",
+        description:
+          "Write down the main reason you used this remedy, for example pain relief, digestion, sleep, or general strength.",
+      },
+      {
+        title: "Observe how you felt after",
+        description:
+          "Notice how you feel over the next 24 to 48 hours, including any improvement, no change, or side effects.",
+      },
+      {
+        title: "Log your reflection",
+        description:
+          "Write a short note about what you noticed, then come back here and mark the task as complete.",
+      },
+    ],
+    proofType: "self-report",
+    isTraditional: true,
+    culture: "East African",
+  },
+];
+
+export function getTaskById(id: string): HealthTask | undefined {
+  return mockTasks.find((task) => task.id === id);
+}


### PR DESCRIPTION

## Summary

This PR implements the task detail experience for health tasks and adds it to the new `/tasks` listing. closes  #159 

- Adds a `/tasks` page that lists mock health tasks using `HealthTaskCard` and routes into `/tasks/[id]`.
- Implements the dynamic `/tasks/[id]` route which loads tasks from `lib/mock/tasks` and shows a rich detail view, including education, steps, and completion actions.
- Introduces `TaskDetailPage` with support for both self‑report and photo‑required tasks, including file upload/validation, preview, and an inline XLM reward success state.

## Screenshots

<img width="1324" height="721" alt="image" src="https://github.com/user-attachments/assets/c19a9979-6263-4e18-95d2-07b6e30591bc" />

<img width="1339" height="719" alt="image" src="https://github.com/user-attachments/assets/8913f948-aa8e-4b59-898d-3619589f9eff" />

<img width="1345" height="721" alt="image" src="https://github.com/user-attachments/assets/88534ba5-ce2c-4139-b0f8-6a3b6b3e05f1" />

<img width="1336" height="690" alt="image" src="https://github.com/user-attachments/assets/aa5bc935-2bc4-43bf-aa47-203292738a90" />

<img width="1345" height="665" alt="image" src="https://github.com/user-attachments/assets/f34542e6-f189-43c1-875e-a1df178e4b0f" />

<img width="1348" height="728" alt="image" src="https://github.com/user-attachments/assets/adb6e121-5112-4252-b543-a18fab62b02e" />

<img width="376" height="582" alt="image" src="https://github.com/user-attachments/assets/8869a5ef-e309-4b10-8c1b-394d184482f7" />

<img width="372" height="603" alt="image" src="https://github.com/user-attachments/assets/85710f1c-fa43-442d-8722-130d4da95e2b" />

## Details

- Created `lib/mock/tasks.ts` with typed `HealthTask` data including `whyItMatters`, step-by-step instructions, proof type, reward amount, and traditional context metadata.
- Added `app/tasks/page.tsx` to surface the available tasks and navigate to `/tasks/[id]` via `HealthTaskCard`.
- Added `app/tasks/[id]/page.tsx` as an async dynamic route that reads `params.id`, fetches the task from `lib/mock/tasks`, and calls `notFound()` for unknown IDs.
- Built `TaskDetailPage` to show:
  - A header card with large icon, task name, category badge, proof-type badge (camera/clipboard), and XLM reward badge (coin icon).
  - A “Why this matters” section using copy from the mock data.
  - Numbered step-by-step instructions without redundant icons.
  - A traditional context callout that only renders when `isTraditional` is true.
- For photo-required tasks:
  - Added a camera-driven upload affordance with JPG/PNG validation and 5MB max size.
  - Shows an inline image preview card with filename under the thumbnail.
  - Blocks completion until a valid image is selected.
- For self-report tasks:
  - Shows a single “Mark Complete” button and disables it after completion to avoid double-claiming.
- After successful completion (both proof types):
  - Renders an inline reward panel with XLM coin animation, earned amount, and a “View Reward” button linking to `/services/xlm-rewards`.
- The back button on the detail page uses `router.back()` for a natural return to the previous list.

## Acceptance Criteria Check

- `/tasks/[id]` is a dynamic route that reads `params.id` and renders the correct task.
- Tasks are loaded from `lib/mock/tasks.ts` by ID; invalid IDs hit `notFound()`.
- Photo upload enforces JPG/PNG and 5MB max and shows a visual preview before submit.
- Self-report completion and photo submission both disable the primary button after success.
- XLM earned is displayed with a coin animation and a “View Reward” CTA to the XLM rewards page.
- Traditional context copy is shown only when `task.isTraditional === true`.
- Back navigation uses `router.back()` instead of a hardcoded link.