### PR TITLE
feat(tasks): enhance TaskFilters with reset button, active sort badge…

### DIFF
--- a/components/tasks/TaskFilters.tsx
+++ b/components/tasks/TaskFilters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { X, ChevronDown, ListFilter } from "lucide-react";
+import { X, ChevronDown, ListFilter, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
@@ -40,22 +40,35 @@ export function TaskFilters({
   onFilterChange,
   onClearAll,
 }: TaskFiltersProps) {
-  const hasActiveFilters = activeCategory !== "All" || activeStatus !== "All";
+  const hasActiveFilters =
+    activeCategory !== "All" ||
+    activeStatus !== "All" ||
+    activeSort !== "newest";
+
+  const activeSortLabel =
+    SORT_OPTIONS.find((o) => o.value === activeSort)?.label ?? "Sort";
 
   return (
-    <div className="space-y-4">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        {/* Category Filter Pills (Mobile Scrollable) */}
-        <div className="flex items-center gap-2 overflow-x-auto pb-2 sm:pb-0 no-scrollbar -mx-4 px-4 sm:mx-0 sm:px-0">
+    <div className="space-y-3">
+      {/* ── Row 1: category pills + controls ── */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        {/* Category pills — horizontally scrollable on mobile */}
+        <div
+          role="group"
+          aria-label="Filter by category"
+          className="flex items-center gap-2 overflow-x-auto pb-1 sm:pb-0 no-scrollbar -mx-4 px-4 sm:mx-0 sm:px-0"
+        >
           {CATEGORIES.map((cat) => (
             <button
               key={cat}
+              type="button"
               onClick={() => onFilterChange("category", cat)}
+              aria-pressed={activeCategory === cat}
               className={cn(
                 "whitespace-nowrap px-4 py-2 rounded-full text-xs font-bold transition-all border",
                 activeCategory === cat
                   ? "bg-terra text-white border-terra shadow-sm"
-                  : "bg-white text-earth/70 border-terra/10 hover:border-terra/30",
+                  : "bg-white text-earth/70 border-terra/10 hover:border-terra/30 hover:bg-cream",
               )}
             >
               {cat}
@@ -63,25 +76,38 @@ export function TaskFilters({
           ))}
         </div>
 
-        <div className="flex items-center gap-2">
-          {/* Status Filter */}
+        {/* ── Right-side controls group ── */}
+        <div
+          role="group"
+          aria-label="Sort and status filters"
+          className="flex items-center gap-2 flex-shrink-0"
+        >
+          {/* Status dropdown */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button className="flex items-center gap-2 px-3 py-2 bg-white border border-terra/10 rounded-2xl text-xs font-bold text-earth hover:bg-cream transition-colors">
-                <ListFilter className="h-3.5 w-3.5 text-terra" />
+              <button
+                type="button"
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-2xl text-xs font-bold transition-colors border",
+                  activeStatus !== "All"
+                    ? "bg-earth text-white border-earth"
+                    : "bg-white text-earth border-terra/10 hover:bg-cream",
+                )}
+              >
+                <ListFilter className="h-3.5 w-3.5" />
                 {activeStatus === "All" ? "Status" : activeStatus}
                 <ChevronDown className="h-3.5 w-3.5 opacity-50" />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="rounded-xl border-terra/10"
-            >
+            <DropdownMenuContent align="end" className="rounded-xl border-terra/10">
               {STATUSES.map((s) => (
                 <DropdownMenuItem
                   key={s}
-                  onClick={() => onFilterChange("status", s)} // Pass "Available", "Completed", etc.
-                  className="text-xs font-medium cursor-pointer focus:bg-terra/5"
+                  onClick={() => onFilterChange("status", s)}
+                  className={cn(
+                    "text-xs font-medium cursor-pointer focus:bg-terra/5",
+                    activeStatus === s && "text-terra font-bold",
+                  )}
                 >
                   {s}
                 </DropdownMenuItem>
@@ -89,59 +115,103 @@ export function TaskFilters({
             </DropdownMenuContent>
           </DropdownMenu>
 
-          {/* Sort Filter */}
+          {/* Sort dropdown */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <button className="flex items-center gap-2 px-3 py-2 bg-white border border-terra/10 rounded-2xl text-xs font-bold text-earth hover:bg-cream transition-colors">
-                Sort
+              <button
+                type="button"
+                className={cn(
+                  "flex items-center gap-2 px-3 py-2 rounded-2xl text-xs font-bold transition-colors border",
+                  activeSort !== "newest"
+                    ? "bg-earth text-white border-earth"
+                    : "bg-white text-earth border-terra/10 hover:bg-cream",
+                )}
+              >
+                {activeSort !== "newest" ? activeSortLabel : "Sort"}
                 <ChevronDown className="h-3.5 w-3.5 opacity-50" />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              className="rounded-xl border-terra/10"
-            >
+            <DropdownMenuContent align="end" className="rounded-xl border-terra/10">
               {SORT_OPTIONS.map((opt) => (
                 <DropdownMenuItem
                   key={opt.value}
                   onClick={() => onFilterChange("sort", opt.value)}
-                  className="text-xs font-medium cursor-pointer"
+                  className={cn(
+                    "text-xs font-medium cursor-pointer focus:bg-terra/5",
+                    activeSort === opt.value && "text-terra font-bold",
+                  )}
                 >
                   {opt.label}
                 </DropdownMenuItem>
               ))}
             </DropdownMenuContent>
           </DropdownMenu>
+
+          {/* Reset button — only visible when filters are active */}
+          {hasActiveFilters && (
+            <button
+              type="button"
+              onClick={onClearAll}
+              title="Reset all filters"
+              className="flex items-center gap-1.5 px-3 py-2 rounded-2xl text-xs font-bold text-terra border border-terra/20 bg-terra/5 hover:bg-terra/10 transition-colors"
+            >
+              <RotateCcw className="h-3.5 w-3.5" />
+              Reset
+            </button>
+          )}
         </div>
       </div>
 
-      {/* Active Filter Dismissible Badges */}
+      {/* ── Row 2: active filter badges ── */}
       {hasActiveFilters && (
-        <div className="flex flex-wrap items-center gap-2 pt-1">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label="Active filters"
+          className="flex flex-wrap items-center gap-2 pt-1"
+        >
+          <span className="text-[11px] font-semibold text-muted uppercase tracking-wider">
+            Active:
+          </span>
+
           {activeCategory !== "All" && (
             <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-terra text-white text-[10px] font-bold uppercase tracking-wider">
               {activeCategory}
-              <X
-                className="h-3 w-3 cursor-pointer"
+              <button
+                type="button"
+                aria-label={`Remove ${activeCategory} filter`}
                 onClick={() => onFilterChange("category", "All")}
-              />
+              >
+                <X className="h-3 w-3" />
+              </button>
             </span>
           )}
+
           {activeStatus !== "All" && (
             <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-earth text-white text-[10px] font-bold uppercase tracking-wider">
               {activeStatus}
-              <X
-                className="h-3 w-3 cursor-pointer"
+              <button
+                type="button"
+                aria-label={`Remove ${activeStatus} filter`}
                 onClick={() => onFilterChange("status", "All")}
-              />
+              >
+                <X className="h-3 w-3" />
+              </button>
             </span>
           )}
-          <button
-            onClick={onClearAll}
-            className="text-[11px] font-bold text-terra/70 hover:text-terra transition-colors ml-1 underline underline-offset-4"
-          >
-            Clear all
-          </button>
+
+          {activeSort !== "newest" && (
+            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-amber-100 text-amber-900 text-[10px] font-bold uppercase tracking-wider">
+              {activeSortLabel}
+              <button
+                type="button"
+                aria-label="Remove sort filter"
+                onClick={() => onFilterChange("sort", "newest")}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          )}
         </div>
       )}
     </div>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Summary
Closes #285

## Changes
- \`components/tasks/TaskFilters.tsx\` — added a Reset button (with RotateCcw icon) that appears only when filters are active; active sort now also shows as a dismissible badge; sort and status dropdowns highlight when non-default values are selected; added aria-pressed on category pills and aria-live on badge row for accessibility

## Acceptance criteria
- [x] Filters reset correctly via Reset button
- [x] Individual filter badges are dismissible
- [x] Sort filter now tracked and displayed as a badge
- [x] Layout grouped clearly with right-side controls" \
  --label "ux"
<img width="1867" height="836" alt="savekm" src="https://github.com/user-attachments/assets/711301b7-6878-49a4-992d-782a122b0a28" />
